### PR TITLE
Removes (refuse) status from the posted_job. Adds link to company so …

### DIFF
--- a/app/controllers/transporters_controller.rb
+++ b/app/controllers/transporters_controller.rb
@@ -75,8 +75,6 @@ class TransportersController < ApplicationController
       @company = @transporter.company.name
     end
 
-    
-
 
 
     def transporter_params

--- a/app/jobs/posted_order_job.rb
+++ b/app/jobs/posted_order_job.rb
@@ -6,7 +6,7 @@ class PostedOrderJob < ApplicationJob #ActiveJob::Base
     puts""
     puts " ORDER STATUS = #{order.status}"
     puts""
-      if ['posted', 'taken', 'refuse'].include?(order.status)          # Other statuses has been allowed to be able to let the order #order.status == "posted" 
+      if ['posted', 'taken'].include?(order.status)          # , 'refuse' removed to check what happens// Other statuses has been allowed to be able to let the order #order.status == "posted" 
           if order.radius < MAX_RADIUS
     	      order.radius += DELTA_RADIUS
     	      order.save

--- a/app/views/companies/show.html.erb
+++ b/app/views/companies/show.html.erb
@@ -8,8 +8,8 @@
     <div class="col-md-12 mb-2 mt-2">
       <div class="row">
         <div class="d-inline col-sm-6 company-Showlabels ">  
-           <b><%= Company.human_attribute_name(:name)  %>:</b> 
-        </div>
+           <b><%= Company.human_attribute_name(:name)  %>:</b>
+        </div> 
         <div class="d-inline col-sm-6 mb-3 company-Showinputs">
          <%= @user.name %>
         </div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -109,9 +109,11 @@
           <li class="nav-item">            
             <%= link_to_in_li  I18n.t(:my_profile), url_for(@user), class: 'nav-link' %>
           </li>
-          <li class="nav-item">  
-          <%= link_to  I18n.t(:edit_profile), edit_transporter_path(@user), class: 'nav-link' %>
-          </li>
+          <%#if @user.status != 'busy'%> <!-- Stops Transporter for changing status while busy on a job, IF UNCOMMENTED WORKS STRAY AWAY -->
+            <li class="nav-item">  
+            <%= link_to  I18n.t(:edit_profile), edit_transporter_path(@user), class: 'nav-link' %>
+            </li>
+          <%# end %> 
           <li class="nav-item"> 
            <%= link_to I18n.t(:change_password), edit_transporter_registration_path, class: 'nav-link'  %>
           <li class="nav-item">      

--- a/app/views/orders/_compa-transporter.html.erb
+++ b/app/views/orders/_compa-transporter.html.erb
@@ -6,7 +6,7 @@
           <%= Order.human_attribute_name(:company) %>
         </div>
         <div class="d-inline col-sm-6 mb-3 company-values">
-         <%= @order.transporter.company.name  %>
+         <%= link_to "#{@order.transporter.company.name}", company_path  %>
         </div>
       </div> 
       <div class="row">

--- a/app/views/transporters/_transporter_form.html.erb
+++ b/app/views/transporters/_transporter_form.html.erb
@@ -38,15 +38,19 @@
 <div class="card text-center my-4">
   <div class="card-body card-status my-3">
     <div class="form-group col-md-12 my-4 "> 
+    <% if @transporter.status != 'busy'%> <!-- Stops Transporter for changing status while busy on a job -->
       <div class="form-group col-md-12 transporter-status-card">
         <b><%= form.label :status,:class => "col-sm-5 trans-status"%></b>
         <%= form.select :status, Transporter.statuses.keys[2..4].collect { |status| [Transporter.human_enum_name(:status, status), status] }, {}, { :class => "col-sm-6 transporter-status"} %>
       </div>
+      <% else %>
+       <%= t(:cant_change_status) %>
+    <% end %>
     </div>
   </div>
 </div>
 
-<% if transporter.new_record? %> <!-- Create logic to update Password -->
+<% if transporter.new_record? %> <!-- Creates logic to update Password -->
   <div class="form-group col-md-12">
     <b><%= form.label :password, :class => "col-sm-5 password" %></b>
     <% if @minimum_password_length %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -198,7 +198,6 @@ en:
           deliverArrived: Arrived at Delivery address
           onWayPick: On the way to Pickup address
           refuse: Refuse
-
           #errors may need to indent one back 
       errors:
         messages:
@@ -212,6 +211,8 @@ en:
   this: "Yes"
   no_this: "No"
 
+  cant_change_status: You can't change status while working on a request
+  
   order_statuses_time_heading: ORDER STATUSES - DATE & TIMES 
   company_created: Company was successfully created !! 
   company_updated: Company was successfully updated !!

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -211,6 +211,8 @@ es:
   this: "Sí"
   no_this: "No"
 
+  cant_change_status: No puedes cambiar tu estado mientras estas ejececutando un servicio 
+
   order_statuses_time_heading: ESTADOS DE LA ORDEN - FECHA Y HORA  
   company_created: Has creado tu cuenta exitosamente !! 
   company_updated: Has actualizado tu cuenta exitosamente !!


### PR DESCRIPTION
- Removes (refuse) status from the posted_job. 
- Adds a link to the company on the SHow view so any user can see the company details if needed. 
- Add translations for a comment on user status to Let Transporters know they can't change their status while they are executing a job